### PR TITLE
Clamp bezier dense bake frames to export range

### DIFF
--- a/roblox_animations/animation/serialization.py
+++ b/roblox_animations/animation/serialization.py
@@ -1970,9 +1970,17 @@ def serialize(
         bezier_dense_frames = set()
         for bone_segs in bezier_segments.values():
             for seg_start, seg_end in bone_segs:
-                bezier_dense_frames.update(range(seg_start + 1, seg_end))
+                bezier_dense_frames.update(
+                    frame
+                    for frame in range(seg_start + 1, seg_end)
+                    if frame_start <= frame <= frame_end
+                )
         if subframe_keys or bezier_dense_frames:
-            all_frames_to_bake = sorted(set(base_frames).union(subframe_keys).union(bezier_dense_frames))
+            all_frames_to_bake = sorted(
+                frame
+                for frame in set(base_frames).union(subframe_keys).union(bezier_dense_frames)
+                if frame_start <= frame <= frame_end
+            )
         else:
             all_frames_to_bake = base_frames
 


### PR DESCRIPTION
## Summary

Fixes an export issue where Bezier dense bake frames could be emitted outside the selected scene/export frame range.

In v2.6.2 on Blender 5.1, I had an animation with export range `0..180`, but Roblox Studio imported it as 241 frames because the exported payload still contained generated keyframes outside the intended range.

## Issue

The scene/export range was set correctly, and `export_info.frame_start` / `export_info.frame_end` were also correct.

However, Bezier dense bake frames were added back into `all_frames_to_bake` without being clamped to `frame_start..frame_end`. This allowed generated bake samples outside the selected export range to be emitted in the final payload.

## Fix

Clamp Bezier dense bake frames to `frame_start <= frame <= frame_end`.

Also clamp the final union of base frames, subframe keys, and Bezier dense frames before assigning `all_frames_to_bake`.

This preserves evaluation inside the selected export range, while preventing generated bake samples outside `frame_start..frame_end` from being emitted into the final payload.

## Verification

Tested manually with Blender 5.1 and addon v2.6.2.

Test case:
- Scene/export range: `0..180`
- FPS: 60
- The animation previously exported generated keyframes outside the selected range, up to frame 241

Before:
- Export payload included keyframes outside the range, up to frame 241
- Roblox Studio imported the animation as 241 frames

After:
- Exported keyframes stayed within the intended frame range
- Roblox Studio imported the expected animation length

https://github.com/user-attachments/assets/e34fcef0-1356-4c28-bef2-1358127bd3fd


